### PR TITLE
Revert rename of eini-beam.app.src to eini.app.src

### DIFF
--- a/src/eini.app.src
+++ b/src/eini.app.src
@@ -1,4 +1,4 @@
-{application, 'eini-beam', [
+{application, eini, [
     {description, "An Erlang INI parser"},
     {vsn, git},
     {applications, [kernel, stdlib]},


### PR DESCRIPTION
The application should remain named as eini in order to not need to make too many changes to `aws_credentials` as well as make upgrades easier. The application name should change from `eini-beam` to `eini` in order to match `app.src` name with application name. 